### PR TITLE
Fix typo 'bettery' -> 'battery'

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Example python usage:
 ```python
 from mat2vec.processing import MaterialsTextProcessor
 text_processor = MaterialsTextProcessor()
-text_processor.process("LiCoO2 is a bettery cathode material.")
+text_processor.process("LiCoO2 is a battery cathode material.")
 ```
 > (['CoLiO2', 'is', 'a', 'battery', 'cathode', 'material', '.'], [('LiCoO2', 'CoLiO2')])
 


### PR DESCRIPTION
...unless it is intentional!